### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Expose any [OpenVoiceOS](https://openvoiceos.org) STT plugin as a [Wyoming proto
 
 ## Features
 
-- **Single `Transcript` response** — OVOS STT plugins are non-streaming, so the full text is returned in one `Transcript` (matching the `wyoming-faster-whisper` reference)
-- **Automatic audio conversion** — All incoming audio is converted to 16 kHz / 16-bit / mono PCM via `AudioChunkConverter`
-- **Thread-safe** — Blocking `stt.execute()` is offloaded via `asyncio.to_thread()` so the event loop stays responsive
-- **Language propagation** — Reads `language` from `Transcribe` event and populates it on `Transcript`
-- **Error reporting** — Failures are sent back as Wyoming `Error` events
-- **Signal handling** — Graceful shutdown on SIGINT/SIGTERM
+- **Single `Transcript` response**: OVOS STT plugins are non-streaming, so the bridge returns the full text in one `Transcript` (matching the `wyoming-faster-whisper` reference).
+- **Automatic audio conversion**: `AudioChunkConverter` converts all incoming audio to 16 kHz / 16-bit / mono PCM.
+- **Thread-safe**: `asyncio.to_thread()` offloads the blocking `stt.execute()` call so the event loop stays responsive.
+- **Language propagation**: The bridge reads `language` from the `Transcribe` event and sets it on the `Transcript`.
+- **Error reporting**: The bridge sends failures back as Wyoming `Error` events.
+- **Signal handling**: The bridge shuts down gracefully on SIGINT/SIGTERM.
 
 ## Installation
 
@@ -103,11 +103,11 @@ wyoming-ovos-stt --uri unix:///run/wyoming-stt.sock \
 
 | Argument | Required | Default | Description |
 |---|---|---|---|
-| `--plugin-name` | Yes | — | OVOS STT plugin module name (e.g. `ovos-stt-plugin-server`) |
-| `--uri` | **Yes** | — | `tcp://HOST:PORT` or `unix:///path` |
+| `--plugin-name` | Yes | none | OVOS STT plugin module name (e.g. `ovos-stt-plugin-server`) |
+| `--uri` | Yes | none | `tcp://HOST:PORT` or `unix:///path` |
 | `--debug` | No | `False` | Enable DEBUG-level logging |
 | `--log-format` | No | `%(levelname)s:%(name)s:%(message)s` | Python log format string |
-| `--version` | No | — | Print version and exit |
+| `--version` | No | none | Print version and exit |
 
 > **Note:** `--uri` is required (unlike the TTS and wake-word bridges which default to `stdio://`) because the STT bridge is designed for persistent TCP connections.
 
@@ -127,22 +127,22 @@ Client → AudioStart(rate=16000, width=2, channels=1)
 Server → Transcript(text="hello world", language="en-US")
 ```
 
-The connection is closed after each transcription (single-use handler pattern, matching the upstream `wyoming-faster-whisper` reference). Audio must be 16 kHz / 16-bit / mono PCM; the bridge converts automatically.
+The connection closes after each transcription (single-use handler pattern, matching the upstream `wyoming-faster-whisper` reference). Audio must be 16 kHz / 16-bit / mono PCM. The bridge converts it automatically.
 
 ## Supported Plugin Types
 
 Any OVOS STT plugin implementing `STT` from `ovos_plugin_manager.templates.stt`:
 
-- `ovos-stt-plugin-server` — proxy to remote STT servers
-- `ovos-stt-plugin-whisper` — OpenAI Whisper (local)
-- `ovos-stt-plugin-vosk` — Vosk offline speech recognition
-- `ovos-stt-plugin-chromium` — Chrome/Chromium's Web Speech API
-- `ovos-stt-plugin-pocketsphinx` — CMU PocketSphinx
-- `ovos-stt-plugin-whispercpp` — Whisper.cpp binding
-- `ovos-stt-plugin-fasterwhisper` — CTranslate2-accelerated Whisper
-- `ovos-stt-plugin-google` — Google Cloud Speech-to-Text
-- `ovos-stt-plugin-azure` — Microsoft Azure Speech
-- `ovos-stt-plugin-amazon` — Amazon Transcribe
+- `ovos-stt-plugin-server`: proxy to remote STT servers
+- `ovos-stt-plugin-whisper`: OpenAI Whisper (local)
+- `ovos-stt-plugin-vosk`: Vosk offline speech recognition
+- `ovos-stt-plugin-chromium`: Chrome/Chromium's Web Speech API
+- `ovos-stt-plugin-pocketsphinx`: CMU PocketSphinx
+- `ovos-stt-plugin-whispercpp`: Whisper.cpp binding
+- `ovos-stt-plugin-fasterwhisper`: CTranslate2-accelerated Whisper
+- `ovos-stt-plugin-google`: Google Cloud Speech-to-Text
+- `ovos-stt-plugin-azure`: Microsoft Azure Speech
+- `ovos-stt-plugin-amazon`: Amazon Transcribe
 
 ## Documentation
 
@@ -151,6 +151,13 @@ Detailed docs live in [`docs/`](docs/index.md):
 - [Configuration](docs/configuration.md)
 - [Home Assistant](docs/home_assistant.md)
 - [Wyoming protocol](docs/protocol.md)
+
+## Related projects
+
+- [wyoming-ovos-tts](https://github.com/OpenVoiceOS/wyoming-ovos-tts): the matching Wyoming bridge for OVOS TTS plugins.
+- [wyoming-ovos-wakeword](https://github.com/OpenVoiceOS/wyoming-ovos-wakeword): the matching Wyoming bridge for OVOS wake-word plugins.
+- [ovos-wyoming-docker](https://github.com/OpenVoiceOS/ovos-wyoming-docker): Docker images that bundle these bridges.
+- [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): loads and manages the OVOS STT plugins this bridge exposes.
 
 ## Credits
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,17 @@
 # Configuration
 
-The bridge itself is configured with CLI flags; the **STT plugin** is configured
-through `mycroft.conf` (the standard OVOS config stack), read at startup.
+CLI flags configure the bridge itself. `mycroft.conf` (the standard OVOS config
+stack) configures the **STT plugin**, and the bridge reads it at startup.
 
 ## CLI
 
 | Argument | Required | Default | Meaning |
 | --- | --- | --- | --- |
-| `--plugin-name` | Yes | — | OVOS STT plugin module name (e.g. `ovos-stt-plugin-server`) |
-| `--uri` | Yes | — | `tcp://HOST:PORT` or `unix:///path` |
+| `--plugin-name` | Yes | none | OVOS STT plugin module name (e.g. `ovos-stt-plugin-server`) |
+| `--uri` | Yes | none | `tcp://HOST:PORT` or `unix:///path` |
 | `--debug` | No | `False` | DEBUG-level logging |
 | `--log-format` | No | `%(levelname)s:%(name)s:%(message)s` | Python log format |
-| `--version` | No | — | print version and exit |
+| `--version` | No | none | print version and exit |
 
 `--uri` is required (unlike the TTS and wake-word bridges, which default to
 `stdio://`) because the STT bridge is meant for a persistent TCP/Unix endpoint.
@@ -38,11 +38,11 @@ section key must match the value passed to `--plugin-name`:
 
 ## Language resolution
 
-For each request the language is taken from, in order:
+For each request, the bridge takes the language from, in order:
 
-1. the `language` field of the Wyoming `Transcribe` event (sent by the client);
-2. `stt.<plugin-name>.lang` in `mycroft.conf`;
-3. the top-level `lang`.
+1. the `language` field of the Wyoming `Transcribe` event (sent by the client)
+2. `stt.<plugin-name>.lang` in `mycroft.conf`
+3. the top-level `lang`
 
 The resolved language is advertised in the `Info` response and echoed back on the
 `Transcript`.
@@ -52,4 +52,7 @@ The resolved language is advertised in the `Info` response and echoed back on th
 Any plugin implementing `STT` from `ovos_plugin_manager.templates.stt`, e.g.
 `ovos-stt-plugin-server`, `ovos-stt-plugin-fasterwhisper`,
 `ovos-stt-plugin-vosk`, `ovos-stt-plugin-chromium`. Install the plugin alongside
-the bridge — it is not pulled in automatically.
+the bridge. It is not pulled in automatically.
+
+---
+[Home](index.md) · [Home Assistant →](home_assistant.md)

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -30,3 +30,6 @@ bridge does support zeroconf discovery.)
 - Audio is converted to 16 kHz / 16-bit / mono internally, so HA's microphone
   format does not need to match the plugin.
 - Run one bridge process per STT plugin/port if you want to offer several engines.
+
+---
+[← Configuration](configuration.md) · [Home](index.md) · [Wyoming protocol →](protocol.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,12 +10,12 @@ incoming Wyoming audio to 16 kHz / 16-bit / mono, runs the plugin's blocking
 
 ## Pages
 
-- **[Configuration](configuration.md)** — selecting a plugin and its
-  `mycroft.conf` settings, and how the language is resolved.
-- **[Home Assistant](home_assistant.md)** — adding the bridge as a Wyoming STT
+- **[Configuration](configuration.md)**: selecting a plugin and its
+  `mycroft.conf` settings, and how the bridge resolves the language.
+- **[Home Assistant](home_assistant.md)**: adding the bridge as a Wyoming STT
   service.
-- **[Wyoming protocol](protocol.md)** — the event flow and why a single
-  `Transcript` is sent (matching `wyoming-faster-whisper`).
+- **[Wyoming protocol](protocol.md)**: the event flow and why the bridge sends
+  a single `Transcript` (matching `wyoming-faster-whisper`).
 
 ## Quickstart
 
@@ -27,8 +27,8 @@ wyoming-ovos-stt --uri tcp://0.0.0.0:7891 \
                  --plugin-name ovos-stt-plugin-server
 ```
 
-Point Home Assistant's Wyoming integration at `host:7891` — see
-[Home Assistant](home_assistant.md).
+Point Home Assistant's Wyoming integration at `host:7891`. See
+[Home Assistant](home_assistant.md) for details.
 
 ## Docker
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -38,5 +38,8 @@ loop stays responsive while a slow plugin transcribes.
 
 ## Errors
 
-Any exception while handling an event is reported to the client as a Wyoming
-`Error(text, code)` event, and the connection is closed.
+If an exception occurs while handling an event, the bridge reports it to the
+client as a Wyoming `Error(text, code)` event and closes the connection.
+
+---
+[← Home Assistant](home_assistant.md) · [Home](index.md)


### PR DESCRIPTION
Rewrites the README and docs/*.md prose in Simplified Technical English: shorter sentences, active voice, and no em dashes or slop phrasing. Adds a Related projects section linking sibling OVOS Wyoming bridges, and adds the standard prev/home/next navigation footer to the docs pages. All facts, code blocks, badges, and the license/funding section are unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)